### PR TITLE
feat: move kochava sdk init out of factory

### DIFF
--- a/Example/Rudder-Kochava/_AppDelegate.m
+++ b/Example/Rudder-Kochava/_AppDelegate.m
@@ -10,11 +10,15 @@
 #import <Rudder/Rudder.h>
 #import <RudderKochavaFactory.h>
 #import "Rudder_Kochava_Example-Swift.h"
+@import KochavaTracker;
 
 @implementation _AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
+    
+    // Initialise the Kochava SDK
+    [self initKochavaSDK];
     
     /// Copy the `SampleRudderConfig.plist` and rename it to`RudderConfig.plist` on the same directory.
     /// Update the values as per your need.
@@ -34,6 +38,13 @@
     }
     
     return YES;
+}
+
+-(void) initKochavaSDK {
+    // https://support.kochava.com/sdk-integration/ios-sdk-integration/
+    KVALog.shared.level = KVALogLevel.trace;
+    KVATracker.shared.appTrackingTransparency.enabledBool = YES;
+    [KVATracker.shared startWithAppGUIDString:@"_YOUR_APP_GUID_"];
 }
 
 

--- a/Rudder-Kochava/Classes/RudderKochavaIntegration.m
+++ b/Rudder-Kochava/Classes/RudderKochavaIntegration.m
@@ -19,24 +19,7 @@ static NSDictionary *eventsMapping;
 - (instancetype) initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client withRudderConfig:(RSConfig *)rudderConfig {
     self = [super init];
     if (self) {
-        [RSLogger logDebug:@"Initializing Kochava Factory"];
         [self setEventsMapping];
-        if (config == nil) {
-            [RSLogger logError:@"Failed to Initialize Kochava Factory as Config is null"];
-        }
-        
-        self.appGUID = config[@"apiKey"];
-        if (self.appGUID!=nil) {
-            [self setLogLevel:rudderConfig.logLevel];
-            if ([[config objectForKey:@"appTrackingTransparency"] boolValue]) {
-                KVATracker.shared.appTrackingTransparency.enabledBool = YES;
-            }
-            [KVATracker.shared startWithAppGUIDString:self.appGUID];
-            [RSLogger logDebug:@"Initialized Kochava Factory"];
-        }
-        else {
-            [RSLogger logWarn:@"Failed to Initialize Kochava Factory"];
-        }
     }
     return self;
 }
@@ -138,30 +121,6 @@ static NSDictionary *eventsMapping;
 }
 
 #pragma mark - Utils
-
-- (void) setLogLevel:(int) rsLogLevel {
-    if (rsLogLevel == RSLogLevelVerbose) {
-        KVALog.shared.level = KVALogLevel.trace;
-        return;
-    }
-    if (rsLogLevel == RSLogLevelDebug) {
-        KVALog.shared.level = KVALogLevel.debug;
-        return;
-    }
-    if (rsLogLevel == RSLogLevelInfo) {
-        KVALog.shared.level = KVALogLevel.info;
-        return;
-    }
-    if (rsLogLevel == RSLogLevelWarning) {
-        KVALog.shared.level = KVALogLevel.warn;
-        return;
-    }
-    if (rsLogLevel == RSLogLevelError) {
-        KVALog.shared.level = KVALogLevel.error;
-        return;
-    }
-    KVALog.shared.level = KVALogLevel.never;
-}
 
 - (NSMutableDictionary*) setCurrency:(NSMutableDictionary*) eventProperties withEvent: (KVAEvent*) event {
     if (eventProperties[KeyCurrency]) {


### PR DESCRIPTION
## Description

- Moved Kochava SDK init out of the factory class. Now, the user of this integration needs to init the SDK. This is necessary for the proper functioning of the Flutter Kochava integration.
- Added Kochava SDK init snippet in the sample app.