### PR TITLE
ci: add deploy to beta cocoapod action

### DIFF
--- a/.github/workflows/deploy-beta-cocoapods.yml
+++ b/.github/workflows/deploy-beta-cocoapods.yml
@@ -1,0 +1,22 @@
+name: Beta deploy to Cocoapods
+
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-cocoapods-beta:
+    name: Beta deploy to Cocoapods
+    runs-on: macOS-latest
+    if: startsWith(github.ref, 'refs/heads/beta-release/')
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Publish to CocoaPod
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push --allow-warnings


### PR DESCRIPTION
# Description

In this PR, we added a GitHub action to deploy the Rudder-Kochava pod as a beta.
